### PR TITLE
Sanitize app name string to support path names with special characters

### DIFF
--- a/src/react-native-bundle-visualizer.js
+++ b/src/react-native-bundle-visualizer.js
@@ -9,11 +9,15 @@ const open = require('open');
 const { explore } = require('source-map-explorer');
 const pkgJSON = JSON.parse(fs.readFileSync('./package.json'));
 
+function sanitizeString(str) {
+  return str.replace(/[^\w]/gi, '');
+}
+
 function getAppName() {
-  if (pkgJSON.name) return pkgJSON.name;
+  if (pkgJSON.name) return sanitizeString(pkgJSON.name);
   try {
     const appJSON = JSON.parse(fs.readFileSync('./app.json'));
-    return appJSON.name || appJSON.expo.name || 'UnknownApp';
+    return sanitizeString(appJSON.name) || sanitizeString(appJSON.expo.name) || 'UnknownApp';
   } catch (err) {
     return 'UnknownApp';
   }


### PR DESCRIPTION
This PR fixes issue Visualizer script fails when package name is scoped #21.
Scoped packages within a monorepo usually have names such as @repo/package-name. 
This fix will strip all special characters from the app name string.