### PR TITLE
Updated docs to reflect Expo SDK 41

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,38 +16,45 @@ Make sure [npx](https://github.com/npm/npx) is installed and run the following c
 
 `npx react-native-bundle-visualizer`
 
-And when using Expo:
+And when using Expo SDK 40 or lower. Learn more: [Expo extensions](http://expo.fyi/expo-extension-migration).
 
 `npx react-native-bundle-visualizer --expo managed`
 
 ### Or install as a dev-dependency
 
-`yarn add --dev react-native-bundle-visualizer`
+```sh
+yarn add --dev react-native-bundle-visualizer
+```
 
 And run it:
 
-    yarn run react-native-bundle-visualizer
+```
+yarn run react-native-bundle-visualizer
+```
 
 _or when using npm:_
 
-    npm install --save-dev react-native-bundle-visualizer
-    ./node_modules/.bin/react-native-bundle-visualizer
+```
+npm install --save-dev react-native-bundle-visualizer ./node_modules/.bin/react-native-bundle-visualizer
+```
 
 ## Command line arguments
 
 All command-line arguments are optional. By default a production build will be created for the `ios` platform.
 
-| Option          | Description                                                                                                                                                   | Example                           |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| `platform`      | Platform to build (default is **ios**)                                                                                                                        | `--platform android`              |
-| `expo`          | Expo target, **managed** or **bare**. This ensures that the project is bundled with expo settings and that `.expo` file extensions are handled appropriately. | `--expo bare`                     |
-| `dev`           | Dev or production build (default is **false**)                                                                                                                | `--dev false`                     |
-| `entry-file`    | Entry-file (when omitted tries to auto-resolve it)                                                                                                            | `--entry-file ./index.android.js` |
-| `bundle-output` | Output bundle-file (default is **tmp**)                                                                                                                       | `--bundle-output ./myapp.bundle`  |
-| `format`        | Output format **html**, **json** or **tsv** (default is **html**) (see [source-map-explorer options](https://github.com/danvk/source-map-explorer#options))   | `--format json`                   |
-| `only-mapped`   | Exclude "unmapped" bytes from the output (default is **false**). This will result in total counts less than the file size.                                    | `--only-mapped`                   |
-| `verbose`       | Dumps additional output to the console (default is **false**)                                                                                                 | `--verbose`                       |
-| `reset-cache`   | Removes cached react-native files (default is **false**)                                                                                                      | `--reset-cache`                   |
+| Option          | Description                                                                                                                                                  | Example                          |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
+| `platform`      | Platform to build (default is **ios**)                                                                                                                       | `--platform ios`                 |
+| `expo`          | (Deprecated in SDK 41+) Expo target, **managed** or **bare**. Ensures that the project is bundled with expo settings and that `.expo.*` extensions are used. | `--expo bare`                    |
+| `dev`           | Dev or production build (default is **false**)                                                                                                               | `--dev false`                    |
+| `entry-file`    | Entry-file (when omitted tries to auto-resolve it)                                                                                                           | `--entry-file ./index.ios.js`    |
+| `bundle-output` | Output bundle-file (default is **tmp**)                                                                                                                      | `--bundle-output ./myapp.bundle` |
+| `format`        | Output format **html**, **json** or **tsv** (default is **html**) (see [source-map-explorer options][smeo])                                                  | `--format json`                  |
+| `only-mapped`   | Exclude "unmapped" bytes from the output (default is **false**). This will result in total counts less than the file size.                                   | `--only-mapped`                  |
+| `verbose`       | Dumps additional output to the console (default is **false**)                                                                                                | `--verbose`                      |
+| `reset-cache`   | Removes cached react-native files (default is **false**)                                                                                                     | `--reset-cache`                  |
+
+[smeo]: https://github.com/danvk/source-map-explorer#options
 
 ## Usage with older react-native versions and the Haul bundler
 


### PR DESCRIPTION
SDK 41 has improved source maps and we dropped support for the `.expo` extension.

## Before

<img width="1761" alt="source-map-before" src="https://user-images.githubusercontent.com/9664363/114604098-62447300-9c4d-11eb-8d46-97791175e857.png">

## After

<img width="1761" alt="source-map-after" src="https://user-images.githubusercontent.com/9664363/114604108-640e3680-9c4d-11eb-9c4f-3479dd7c575c.png">
