### PR TITLE
Support Yarn monorepo context

### DIFF
--- a/src/react-native-bundle-visualizer.js
+++ b/src/react-native-bundle-visualizer.js
@@ -91,8 +91,9 @@ if (expoTargetDeprecated) {
     )
   );
 }
-
-const bundlePromise = execa('./node_modules/.bin/react-native', commands);
+const reactNativeDir = path.dirname(require.resolve('react-native/package.json'))
+const reactNativeBin = path.join(reactNativeDir, './cli.js')
+const bundlePromise = execa(reactNativeBin, commands);
 bundlePromise.stdout.pipe(process.stdout);
 
 // Upon bundle completion, run `source-map-explorer`


### PR DESCRIPTION
With Yarn, the React Native binary is hoisted from the individual workspace to the repository root.
Hence this command fails in such an environment, as the binary isn't located in the fixed path described here.

The proposed change resolves the React Native binary's location via [Node mechanisms](https://nodejs.org/api/modules.html#modules_all_together).