### PR TITLE
fix - verbose bundle size output is no longer [object Object]

### DIFF
--- a/src/react-native-bundle-visualizer.js
+++ b/src/react-native-bundle-visualizer.js
@@ -167,9 +167,9 @@ bundlePromise
   .then((result) => {
     if (verbose) {
       result.bundles.forEach((bundle) => {
-        Object.entries(bundle.files).forEach(([file, stats]) => {
+        Object.keys(bundle.files).forEach((file) => {
           console.log(
-            chalk.green(file + ', size: ' + stats.size + ' bytes')
+            chalk.green(file + ', size: ' + bundle.files[file]?.size + ' bytes')
           );
         });
       });

--- a/src/react-native-bundle-visualizer.js
+++ b/src/react-native-bundle-visualizer.js
@@ -169,7 +169,7 @@ bundlePromise
       result.bundles.forEach((bundle) => {
         Object.keys(bundle.files).forEach((file) => {
           console.log(
-            chalk.green(file + ', size: ' + bundle.files[file]?.size + ' bytes')
+            chalk.green(file + ', size: ' + bundle.files[file].size + ' bytes')
           );
         });
       });

--- a/src/react-native-bundle-visualizer.js
+++ b/src/react-native-bundle-visualizer.js
@@ -167,9 +167,9 @@ bundlePromise
   .then((result) => {
     if (verbose) {
       result.bundles.forEach((bundle) => {
-        Object.keys(bundle.files).forEach((file) => {
+        Object.entries(bundle.files).forEach(([file, stats]) => {
           console.log(
-            chalk.green(file + ', size: ' + bundle.files[file]?.size + ' bytes')
+            chalk.green(file + ', size: ' + stats.size + ' bytes')
           );
         });
       });

--- a/src/react-native-bundle-visualizer.js
+++ b/src/react-native-bundle-visualizer.js
@@ -169,7 +169,7 @@ bundlePromise
       result.bundles.forEach((bundle) => {
         Object.keys(bundle.files).forEach((file) => {
           console.log(
-            chalk.green(file + ', size: ' + bundle.files[file] + ' bytes')
+            chalk.green(file + ', size: ' + bundle.files[file]?.size + ' bytes')
           );
         });
       });


### PR DESCRIPTION
This fixes the console output of individual file stats when verbose parameter is provided. Prior to the change, size of a file was not printed correctly:

Before:
`[sourceMappingURL], size: [object Object] bytes`

After:
`[sourceMappingURL], size: 35 bytes`