### PR TITLE
fix: use patch version of RN64 to fix android build

### DIFF
--- a/test/RN64/package.json
+++ b/test/RN64/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "17.0.1",
-    "react-native": "0.64.2"
+    "react-native": "0.64.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/test/RN64/yarn.lock
+++ b/test/RN64/yarn.lock
@@ -5093,10 +5093,10 @@ react-native-codegen@^0.0.6:
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
 
-react-native@0.64.2:
-  version "0.64.2"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.64.2.tgz#233b6ed84ac4749c8bc2a2d6cf63577a1c437d18"
-  integrity sha512-Ty/fFHld9DcYsFZujXYdeVjEhvSeQcwuTGXezyoOkxfiGEGrpL/uwUZvMzwShnU4zbbTKDu2PAm/uwuOittRGA==
+react-native@0.64.4:
+  version "0.64.4"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.64.4.tgz#f9870f6951378421881cc66f6b5a6451bef7254d"
+  integrity sha512-nxYt/NrTmGyW6+tOd+Hqp4O8uJ2LLZkN7ispMPDprAq7bwvLkF/GXmDQCZHAEyqXuhIztTtMX41KqFQ6UMCUJQ==
   dependencies:
     "@jest/create-cache-key-function" "^26.5.0"
     "@react-native-community/cli" "^5.0.1-alpha.1"


### PR DESCRIPTION
### Description:

As react-native did some changes to their artifacts distribution strategy, the _**test/RN64**_  doesn't build anymore. So following the solution as proposed [here](https://github.com/facebook/react-native/issues/35210#issuecomment-1304536693), suggests to bump the RN version to the nearest patch version, which fixes the _**test/RN64**_.